### PR TITLE
Fixed Fileaccessproblem for windows version (forum thread 2223)

### DIFF
--- a/creator.cpp
+++ b/creator.cpp
@@ -772,9 +772,19 @@ unsigned int Creator::getUncompressedImageSize()
     unsigned char bufSize[4];
     unsigned int fileSize;
 
+#if defined(_WIN32)
+    // toStdString internally converts filename to utf8, which
+    // windows does not support for fileaccess
+    // so use unchanged 16 Bit unicode here (QChar is 16 Bit)
+    file = _wfopen((const wchar_t *)imageFile.fileName().utf16(), L"rb");
+#else
     file = fopen(imageFile.fileName().toStdString().c_str(), "rb");
+#endif
     if (file == NULL)
+    {
+        emit error("Couldn't open " + imageFile.fileName());
         return 0;
+    }
 
     if (imageFile.fileName().endsWith(".gz")) {
         if (fseek(file, -4, SEEK_END) != 0)

--- a/creator.h
+++ b/creator.h
@@ -138,6 +138,7 @@ protected:
 
 signals:
     void proceedToWriteImageToDevice(const QString& image, const QString& device);
+    void error(const QString& message);
 
 private slots:
     void httpsUrlHandler(const QUrl &url);

--- a/diskwriter.cpp
+++ b/diskwriter.cpp
@@ -59,7 +59,14 @@ void DiskWriter::writeGzCompressedImage(const QString &filename, const QString& 
     QByteArray buf(512*1024*sizeof(char), 0);
 
     // Open source
+#if defined(_WIN32)
+    // toStdString internally converts filename to utf8, which
+    // windows does not support for fileaccess
+    // so use unchanged 16 Bit unicode here
+    gzFile src = gzopen_w((const wchar_t *)filename.utf16(), "rb");
+#else
     gzFile src = gzopen(filename.toStdString().c_str(), "rb");
+#endif
     if (src == NULL) {
         emit error("Couldn't open " + filename);
         this->close();
@@ -125,7 +132,14 @@ void DiskWriter::writeZipCompressedImage(const QString &filename, const QString&
     off_t bytesRead = 0;
 
     // Open source
+#if defined(_WIN32)
+    // toStdString internally converts filename to utf8, which
+    // windows does not support for fileaccess
+    // so use unchanged 16 Bit unicode here
+    gzFile src = gzopen_w((const wchar_t *)filename.utf16(), "rb");
+#else
     gzFile src = gzopen(filename.toStdString().c_str(), "rb");
+#endif
     if (src == NULL) {
         emit error("Couldn't open " + filename);
         this->close();


### PR DESCRIPTION
Fix should be for Windows only (ifdef WIN32)

- WIndows does not support utf8 access for fopen and gzopen API
- changed implementation to wChar pendants
=> Full unicode filenames, I testes even with special unicodes (i.e. Ohmsymbol: C:\JÖRG_Ω\LibreELEC-RPi.arm-7.0.3.img.gz) and it works

See https://forum.libreelec.tv/thread-2223.html