### PR TITLE
Build on newer Linux systems

### DIFF
--- a/downloadmanager.cpp
+++ b/downloadmanager.cpp
@@ -42,6 +42,7 @@ DownloadManager::~DownloadManager()
 QNetworkReply* DownloadManager::get(const QUrl &url)
 {
     QNetworkRequest req(url);
+    req.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     req.setRawHeader("User-Agent", "Wget/1.14 (linux-gnu)");
     req.setRawHeader("Connection", "keep-alive");
     qDebug() << "Getting" << url;

--- a/privileges_unix.h
+++ b/privileges_unix.h
@@ -21,7 +21,6 @@
 
 #include <pwd.h>
 #include <errno.h>
-#include <sys/sysctl.h>
 #include <unistd.h>
 #include <grp.h>
 


### PR DESCRIPTION
When building and testing on Debian testing (Bookworm) it first didn't compile because of the header file, then it wouldn't follow redirects. This fixes both.
Only tested on Debian, but it also build on Ubuntu 20.04.
This was tested with Qt 5.15.2 and Qt 6.2.2