### PR TITLE
show friendly device name in errors in GUI

### DIFF
--- a/creator.cpp
+++ b/creator.cpp
@@ -101,8 +101,8 @@ Creator::Creator(Privileges &privilegesArg, QWidget *parent) :
 
     connect(diskWriterThread, SIGNAL(finished()),
             diskWriter, SLOT(deleteLater()));
-    connect(this, SIGNAL(proceedToWriteImageToDevice(QString,QString)),
-            diskWriter, SLOT(writeImageToRemovableDevice(QString,QString)));
+    connect(this, SIGNAL(proceedToWriteImageToDevice(QString,QString,QString)),
+            diskWriter, SLOT(writeImageToRemovableDevice(QString,QString,QString)));
 
     connect(diskWriter, SIGNAL(bytesWritten(int)),this, SLOT(handleWriteProgress(int)));
     connect(diskWriter, SIGNAL(syncing()), this, SLOT(writingSyncing()));
@@ -1348,7 +1348,7 @@ void Creator::writeFlashButtonClicked()
     msgBox.setWindowTitle(tr("Confirm write"));
     msgBox.setText(tr("Selected device: %1\n"
                       "Are you sure you want to write the image?\n\n"
-                      "Your USB-SD device will be wiped!").arg(destination));
+                      "Your USB-SD device will be wiped!").arg(destinationText));
     msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     msgBox.setDefaultButton(QMessageBox::No);
     int ret = msgBox.exec();
@@ -1363,7 +1363,7 @@ void Creator::writeFlashButtonClicked()
     qint64 deviceSize = devEnumerator->getSizeOfDevice(destination);
     privileges.SetUser();    // back to user
     if (unmounted == false) {
-        flashProgressBarText(tr("Cannot unmount partititons on device %1").arg(destination));
+        flashProgressBarText(tr("Cannot unmount partititons on device %1").arg(destinationText));
         reset();
         return;
     }
@@ -1376,7 +1376,7 @@ void Creator::writeFlashButtonClicked()
     if (uncompressedImageSize > deviceSize) {
         QString uncompressedSizeStr = devEnumerator->sizeToHuman(uncompressedImageSize);
         QString deviceSizeStr = devEnumerator->sizeToHuman(deviceSize);
-        flashProgressBarText(tr("Not enough space on %1 [%2 < %3]").arg(destination).arg(deviceSizeStr).arg(uncompressedSizeStr));
+        flashProgressBarText(tr("Not enough space on %1 [%2 < %3]").arg(destinationText).arg(deviceSizeStr).arg(uncompressedSizeStr));
         reset();
         return;
     }
@@ -1389,7 +1389,7 @@ void Creator::writeFlashButtonClicked()
     privileges.SetRoot();    // root need for opening a device
 
     ui->writeFlashButton->setText(tr("Cance&l"));
-    emit proceedToWriteImageToDevice(imageFile.fileName(), destination);
+    emit proceedToWriteImageToDevice(imageFile.fileName(), destination, destinationText);
 
     speedTime.start();
     averageSpeed = new MovingAverage(20);

--- a/creator.h
+++ b/creator.h
@@ -137,7 +137,7 @@ protected:
     void timerEvent(QTimerEvent *event);
 
 signals:
-    void proceedToWriteImageToDevice(const QString& image, const QString& device);
+    void proceedToWriteImageToDevice(const QString& image, const QString& device, const QString& deviceText);
     void error(const QString& message);
 
 private slots:

--- a/diskwriter.cpp
+++ b/diskwriter.cpp
@@ -31,21 +31,21 @@ void DiskWriter::cancelWrite()
     isCancelled = true;
 }
 
-void DiskWriter::writeImageToRemovableDevice(const QString &filename, const QString &device)
+void DiskWriter::writeImageToRemovableDevice(const QString &filename, const QString &device, const QString& deviceText)
 {
     if (!open(device)) {
-        emit error("Couldn't open " + device);
+        emit error("Couldn't open " + deviceText);
         return;
     }
 
     isCancelled = false;
 
     if (filename.endsWith(".gz"))
-        writeGzCompressedImage(filename, device);
+        writeGzCompressedImage(filename, device, deviceText);
     else if (filename.endsWith(".zip"))
-        writeZipCompressedImage(filename, device);
+        writeZipCompressedImage(filename, device, deviceText);
     else
-        writeUncompressedImage(filename, device);
+        writeUncompressedImage(filename, device, deviceText);
 
     if (isCancelled)
         emit bytesWritten(0);
@@ -53,7 +53,7 @@ void DiskWriter::writeImageToRemovableDevice(const QString &filename, const QStr
         emit finished();
 }
 
-void DiskWriter::writeGzCompressedImage(const QString &filename, const QString& device)
+void DiskWriter::writeGzCompressedImage(const QString &filename, const QString& device, const QString& deviceText)
 {
     int read;
     QByteArray buf(512*1024*sizeof(char), 0);
@@ -96,7 +96,7 @@ void DiskWriter::writeGzCompressedImage(const QString &filename, const QString& 
             buf.truncate(read);
 
         if (this->write(buf) == false) {
-            emit error("Failed to write to " + device + "!");
+            emit error("Failed to write to " + deviceText + "!");
             gzclose(src);
             this->close();
             return;
@@ -112,16 +112,16 @@ void DiskWriter::writeGzCompressedImage(const QString &filename, const QString& 
     this->close();
 }
 
-void DiskWriter::writeUncompressedImage(const QString &filename, const QString& device)
+void DiskWriter::writeUncompressedImage(const QString &filename, const QString& device, const QString& deviceText)
 {
     // if input file is not in gzip format then
     // gzread reads directly from the file
-    writeGzCompressedImage(filename, device);
+    writeGzCompressedImage(filename, device, deviceText);
 }
 
 // zip parts from zipcat.c -- inflate a single-file PKZIP archive to stdout
 // by Sam Hocevar <sam@zoy.org>
-void DiskWriter::writeZipCompressedImage(const QString &filename, const QString& device)
+void DiskWriter::writeZipCompressedImage(const QString &filename, const QString& device, const QString& deviceText)
 {
     int read;
     uint8_t buf4[4];
@@ -212,7 +212,7 @@ void DiskWriter::writeZipCompressedImage(const QString &filename, const QString&
             bufOut.truncate(read);
 
         if (this->write(bufOut) == false) {
-            emit error("Failed to write to " + device + "!");
+            emit error("Failed to write to " + deviceText + "!");
             gzclose(src);
             this->close();
             return;

--- a/diskwriter.h
+++ b/diskwriter.h
@@ -36,14 +36,14 @@ public:
     virtual ~DiskWriter() {}
 
 private:
-    virtual void writeUncompressedImage(const QString &filename, const QString& device);
-    virtual void writeGzCompressedImage(const QString &filename, const QString& device);
-    virtual void writeZipCompressedImage(const QString &filename, const QString& device);
+    virtual void writeUncompressedImage(const QString &filename, const QString& device, const QString& deviceText);
+    virtual void writeGzCompressedImage(const QString &filename, const QString& device, const QString& deviceText);
+    virtual void writeZipCompressedImage(const QString &filename, const QString& device, const QString& deviceText);
     virtual int zipRead(gzFile src, z_streamp stream, QByteArray &buf, QByteArray &bufZip);
 
 public slots:
     void cancelWrite();
-    virtual void writeImageToRemovableDevice(const QString &filename, const QString& device);
+    virtual void writeImageToRemovableDevice(const QString &filename, const QString& device, const QString& deviceText);
 
 signals:
     void bytesWritten(int);


### PR DESCRIPTION
This shows the friendly name in the gui instead of whatever is represented as the device.

instead of `/dev/sda` it will show `Lexar USB stick [14.9G]`.