### PR TITLE
[macOS] fix showing native file dialog

### DIFF
--- a/creator.cpp
+++ b/creator.cpp
@@ -1439,10 +1439,14 @@ void Creator::refreshRemovablesList()
     QVariant previouslySelectedDevice;
     previouslySelectedDevice = settings.value("preferred/removableDevice");
 
+#ifndef Q_OS_MACOS
     privileges.SetRoot();    // root need for opening a device
+#endif
     QStringList devNames = devEnumerator->getRemovableDeviceNames();
     QStringList friendlyNames = devEnumerator->getUserFriendlyNames(devNames);
+#ifndef Q_OS_MACOS
     privileges.SetUser();    // back to user
+#endif
 
     // check for changes
     if (devNames.size() == ui->removableDevicesComboBox->count()) {

--- a/creator.cpp
+++ b/creator.cpp
@@ -38,7 +38,6 @@
 #include <QMimeData>
 #include <QProcess>
 #include <QVersionNumber>
-#include <QOperatingSystemVersion>
 #include <QSignalBlocker>
 
 #if defined(Q_OS_WIN)
@@ -1192,17 +1191,10 @@ void Creator::downloadButtonClicked()
     qDebug() << "saveDir" << saveDir;
     qDebug() << "Whole path" << saveDir + '/' + selectedImage;
 
-    auto flags = QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks;
-#ifdef Q_OS_MAC
-    // TODO: required until QT6 supports OSX Monterrey/Xcode 13 (likely QT 6.3)
-    if (QOperatingSystemVersion::current().majorVersion() >= 12)
-        flags |= QFileDialog::DontUseNativeDialog;
-#endif
-
     saveDir = QFileDialog::getExistingDirectory(this,
                 tr("Directory to store image file"),
                 saveDir,
-                flags);
+                QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
 
     if (saveDir.isEmpty() || selectedImage.isEmpty()) {
         reset();
@@ -1276,19 +1268,10 @@ void Creator::getImageFileNameFromUser()
         qDebug() << "loadDir" << loadDir;
     }
 
-    QFileDialog::Options flags;
-#ifdef Q_OS_MAC
-    // TODO: required until QT6 supports OSX Monterrey/Xcode 13
-    if (QOperatingSystemVersion::current().majorVersion() >= 12)
-        flags |= QFileDialog::DontUseNativeDialog;
-#endif
-
     QString filename = QFileDialog::getOpenFileName(this,
                         tr("Open image file"),
                         loadDir,
-                        tr("Compressed gz image (*img.gz);;Compressed zip image (*img.zip);;Uncompressed image (*.img);;All files (*.*)"),
-                        nullptr,
-                        flags);
+                        tr("Compressed gz image (*img.gz);;Compressed zip image (*img.zip);;Uncompressed image (*.img);;All files (*.*)"));
 
     if (filename.isEmpty()) {
         //ui->fileNameLabel->setText("");


### PR DESCRIPTION
enumerating devices via `diskutil` doesn't require superuser privileges