### PR TITLE
fix windows install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,7 @@ if(WIN32)
     set(CPACK_PACKAGE_FILE_NAME "LibreELEC.USB-SD.Creator.x64")
     set(CPACK_PACKAGE_EXECUTABLES "LibreELEC.USB-SD.Creator;LibreELEC USB-SD Creator x64")
     set(CPACK_GENERATOR INNOSETUP)
+    set(CPACK_PACKAGE_INSTALL_DIRECTORY "${projectDisplayName}")
 elseif(APPLE)
     set(CPACK_PACKAGE_FILE_NAME "LibreELEC.USB-SD.Creator.macOS")
 


### PR DESCRIPTION
the version is not included anymore at the install path. avoids having multiple versions parallel

old:
![image](https://github.com/user-attachments/assets/7f0613de-ca33-4d23-b0a1-92c8f6b1d03e)

new:
![image](https://github.com/user-attachments/assets/8665d62f-e0a3-4a0c-b21a-a1a4c7268747)
