### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a lightweight image writing app with a simple four-step GUI for creating
 
 ## Translation Changes
 
-Changes to master language (en_GB) strings can be submitted via pull request to this GitHub repo. English strings are periodically synchronised to a Transifex project: https://www.transifex.com/libreelec/libreelec-usb-sd-creator allowing contributors to translate them into other languages. Translated strings are periodically synchronised from Transifex back to this repo for inclusion in the next release.
+Changes to master language (en_GB) strings can be submitted via pull request to this GitHub repo. English strings are periodically synchronised to a Transifex project: [https://www.transifex.com/libreelec/libreelec-usb-sd-creator](https://www.transifex.com/libreelec/libreelec-usb-sd-creator) allowing contributors to translate them into other languages. Translated strings are periodically synchronised from Transifex back to this repo for inclusion in the next release.
 
 Pull requests for all other languages will be rejected. You will be asked to submit changes via Transifex.
 
@@ -16,7 +16,7 @@ Please note: languages are translated by people (you) not magic!
 
 ## Issues and Support
 
-Issues should be reported via the forum here: https://forum.libreelec.tv/board/41-usb-sd-creator-support
+Issues should be reported via the forum here: [https://forum.libreelec.tv/board/41-usb-sd-creator-support](https://forum.libreelec.tv/board/41-usb-sd-creator-support)
 
 # **How to compile the USB/SD Creator**
 
@@ -57,7 +57,7 @@ https://jrsoftware.org/isdl.php, download and install the latest stable version.
 
 ### 1. Install msys2 and MinGW
 
-Install the latest msys2 via the installer (not the base installer): https://repo.msys2.org/distrib/x86_64/
+Install the latest msys2 via the installer (not the base installer): [https://repo.msys2.org](https://repo.msys2.org/distrib/x86_64/)
 
 After the install, from the resulting msys2 console install mingw:
 
@@ -147,7 +147,7 @@ aqt install-qt --outputdir %UserProfile%/Qt windows desktop 6.7.2 win64_msvc2019
 
 #### Install Visual Studio Community 2022
 
-Install Visual Studio Community 2022 from: https://visualstudio.microsoft.com/vs/community/. Note that you only require the Desktop C++ package which you can select in the online installer.
+Install Visual Studio Community 2022 from: [https://visualstudio.microsoft.com](https://visualstudio.microsoft.com/vs/community/). Note that you only require the Desktop C++ package which you can select in the online installer.
 
 Note that the command prompt is to be used thoughtout the MSVC build must be started from a standard command prompt for `x64` as follows: `"C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/Tools/VsDevCmd.bat" -arch=x64 -host_arch=x64`.
 

--- a/README.md
+++ b/README.md
@@ -30,29 +30,6 @@ Build instructions are supplied for Windows x64 (Installer and Portable), macOS 
 
 Note: the offical release for Windows is built using Visual Studio
 
-## Install pre-requisites
-
-### 1. Install 7zip
-https://www.7-zip.org/download.html
-
-### 2. Install Git
-https://git-scm.com/download/win
-
-### 3. Install CMake
-https://cmake.org/download, select windows x64 installer and "Add cmake to PATH".
-
-### 4. Install Python
-https://www.python.org/downloads/windows/ select Windows installer (64-bit) for download
-at install select "Add Python to PATH"
-
-### 5. Install Inno Setup (Compiler for Installer)
-
-https://jrsoftware.org/isdl.php, download and install the latest stable version.
-
-#### 5. Add 7-Zip to PATH variable
-
-`C:\Program Files\7-Zip`
-
 ## Building for Windows using MSys2 and MinGW
 
 ### 1. Install msys2 and MinGW
@@ -65,16 +42,22 @@ After the install, from the resulting msys2 console install mingw:
 pacman -S mingw-w64-x86_64-cmake mingw-w64-x86_64-gcc mingw-w64-x86_64-ninja mingw-w64-x86_64-zlib mingw-w64-x86_64-qt6-base mingw-w64-x86_64-qt6-tools
 ```
 
-Add msys2 to PATH: `C:\msys64\mingw64\bin`. Then do a restart of windows.
+Add msys2 to PATH: `C:\msys64\mingw64\bin`.
 
 Note: you must use a standard commnd prompt when using mingw for the build.
 
-### 2. Clone Git Repo
+### 2. Install Inno Setup (Compiler for Installer)
+
+[https://jrsoftware.org](https://jrsoftware.org/isdl.php), download and install the latest stable version.
+
+Add Inno Setup to PATH: `C:\Program Files (x86)\Inno Setup 6`.
+
+### 3. Clone Git Repo
 
 Clone the repository to `%UserProfile%/usb-sd-creator`
 `git clone https://github.com/LibreELEC/usb-sd-creator.git`
 
-### 3. Build USB-SD-Creator
+### 4. Build USB-SD-Creator
 
 Assuming the repo is in your home directory
 
@@ -95,13 +78,6 @@ cmake --preset release-ninja && cmake --build --preset release
 
 ### 4. Build Installer
 
-#### Debug build
-
-```
-cd build
-cpack -C Debug
-```
-
 #### Release build
 
 ##### Create installer
@@ -114,6 +90,13 @@ cpack --preset release
 
 ```
 cpack --preset release -G ZIP
+```
+
+#### Debug build
+
+```
+cd build
+cpack -C Debug
 ```
 
 ### 5. Run USB-SD-Creator


### PR DESCRIPTION
- fixed markdown link format
- removed old deps for windows compiling
- made more clear that innosetup needs to get installed (if you want to create a setup)
- moved setup debug build a step down - it includes a cd to a subdir that is not needed for normal build and could lead to confusion